### PR TITLE
Fix a warn for using as a extension’s lib

### DIFF
--- a/TrafficPolice.xcodeproj/project.pbxproj
+++ b/TrafficPolice.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 		A0C578891DDEF12C005E6F85 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
@@ -315,6 +316,7 @@
 		A0C5788A1DDEF12C005E6F85 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
当我在Today Extension中使用它，就会出现下面这个警告
ld: warning: linking against a dylib which is not safe for use in application extensions
参考：http://blog.csdn.net/tounaobun/article/details/42082769
